### PR TITLE
Changed trace IDs to be of type CPU_ADDR so they can be much more useful

### DIFF
--- a/Source/os.h
+++ b/Source/os.h
@@ -732,7 +732,7 @@ struct  os_flag_grp {                                       /* Event Flag Group 
     CPU_TS               TS;                                /* Timestamp of when last post occurred                   */
 #endif
 #if (defined(OS_CFG_TRACE_EN) && (OS_CFG_TRACE_EN > 0u))
-    CPU_INT16U           FlagID;                            /* Unique ID for third-party debuggers and tracers.       */
+    CPU_ADDR           FlagID;                            /* Unique ID for third-party debuggers and tracers.       */
 #endif
 };
 
@@ -761,7 +761,7 @@ struct os_mem {                                             /* MEMORY CONTROL BL
     OS_MEM              *DbgNextPtr;
 #endif
 #if (defined(OS_CFG_TRACE_EN) && (OS_CFG_TRACE_EN > 0u))
-    CPU_INT16U           MemID;                             /* Unique ID for third-party debuggers and tracers.       */
+    CPU_ADDR           MemID;                             /* Unique ID for third-party debuggers and tracers.       */
 #endif
 };
 
@@ -804,7 +804,7 @@ struct  os_msg_q {                                          /* OS_MSG_Q         
     OS_MSG_QTY           NbrEntriesMax;                     /* Peak number of entries in the queue                    */
 #endif
 #if (defined(OS_CFG_TRACE_EN) && (OS_CFG_TRACE_EN > 0u))
-    CPU_INT16U           MsgQID;                            /* Unique ID for third-party debuggers and tracers.       */
+    CPU_ADDR           MsgQID;                            /* Unique ID for third-party debuggers and tracers.       */
 #endif
 };
 
@@ -839,7 +839,7 @@ struct  os_mutex {                                          /* Mutual Exclusion 
     CPU_TS               TS;
 #endif
 #if (defined(OS_CFG_TRACE_EN) && (OS_CFG_TRACE_EN > 0u))
-    CPU_INT16U           MutexID;                           /* Unique ID for third-party debuggers and tracers.       */
+    CPU_ADDR           MutexID;                           /* Unique ID for third-party debuggers and tracers.       */
 #endif
 };
 
@@ -926,7 +926,7 @@ struct  os_sem {                                            /* Semaphore        
     CPU_TS               TS;
 #endif
 #if (defined(OS_CFG_TRACE_EN) && (OS_CFG_TRACE_EN > 0u))
-    CPU_INT16U           SemID;                             /* Unique ID for third-party debuggers and tracers.       */
+    CPU_ADDR           SemID;                             /* Unique ID for third-party debuggers and tracers.       */
 #endif
 };
 
@@ -991,7 +991,7 @@ struct os_tcb {
     CPU_TS               TS;                                /* Timestamp                                              */
 #endif
 #if (defined(OS_CFG_TRACE_EN) && (OS_CFG_TRACE_EN > 0u))
-    CPU_INT16U           SemID;                             /* Unique ID for third-party debuggers and tracers.       */
+    CPU_ADDR           SemID;                             /* Unique ID for third-party debuggers and tracers.       */
 #endif
     OS_SEM_CTR           SemCtr;                            /* Task specific semaphore counter                        */
 
@@ -1064,7 +1064,7 @@ struct os_tcb {
     CPU_CHAR            *DbgNamePtr;
 #endif
 #if (defined(OS_CFG_TRACE_EN) && (OS_CFG_TRACE_EN > 0u))
-    CPU_INT16U           TaskID;                            /* Unique ID for third-party debuggers and tracers.       */
+    CPU_ADDR           TaskID;                            /* Unique ID for third-party debuggers and tracers.       */
 #endif
 };
 


### PR DESCRIPTION
Trace IDs are too small.
Setting them to the base address type unlocks a lot of potential and optimizations from a tracing stand point.

The next generation of Tracealyzer Recorder will be able to utilize these fields to great effect.