### PR TITLE
feature: add ISR profiling support

### DIFF
--- a/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
+++ b/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
@@ -513,8 +513,10 @@ void  OSTaskSwHook (void)
 #if OS_CFG_TASK_PROFILE_EN > 0u
     ts = OS_TS_GET();
     if (OSTCBCurPtr != OSTCBHighRdyPtr) {
-        OSTCBCurPtr->CyclesDelta  = ts - OSTCBCurPtr->CyclesStart;
-        OSTCBCurPtr->CyclesTotal += (OS_CYCLES)OSTCBCurPtr->CyclesDelta;
+        if (ts > OSTCBCurPtr->CyclesStart) {
+            OSTCBCurPtr->CyclesDelta  = ts - OSTCBCurPtr->CyclesStart;
+            OSTCBCurPtr->CyclesTotal += (OS_CYCLES)OSTCBCurPtr->CyclesDelta;
+        }
     }
 
     OSTCBHighRdyPtr->CyclesStart = ts;

--- a/Source/os_core.c
+++ b/Source/os_core.c
@@ -272,6 +272,18 @@ void  OSIntEnter (void)
         return;                                                 /* Yes                                                  */
     }
 
+#if OS_CFG_TASK_PROFILE_EN > 0u
+    if(OSIntNestingCtr==0) {
+        CPU_TS  ts;
+
+        ts = OS_TS_GET();
+        if(ts > OSTCBCurPtr->CyclesStart) {
+            OSTCBCurPtr->CyclesDelta  = ts - OSTCBCurPtr->CyclesStart;
+            OSTCBCurPtr->CyclesTotal += (OS_CYCLES)OSTCBCurPtr->CyclesDelta;
+        }
+    }
+#endif
+
     OSIntNestingCtr++;                                          /* Increment ISR nesting level                          */
 }
 
@@ -337,6 +349,10 @@ void  OSIntExit (void)
         OSRedzoneHitHook((OS_TCB *)0);
     }
 #endif
+#endif
+
+#if OS_CFG_TASK_PROFILE_EN > 0u
+    OSTCBCurPtr->CyclesStart = OS_TS_GET();
 #endif
 
     OSPrioHighRdy   = OS_PrioGetHighest();                      /* Find highest priority                                */


### PR DESCRIPTION
- add logic to stop measuring task cycles when ISR is entered
- add logic to resume measuring task cycles when ISR is exited
- add logic to avoid getting negative value for cycles in corner case of 32b timestamp overflow